### PR TITLE
chore: change from UNLICENSED to MIT

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.19;
 
 import { Foo } from "../src/Foo.sol";

--- a/src/Foo.sol
+++ b/src/Foo.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.19;
 
 contract Foo {

--- a/test/Foo.t.sol
+++ b/test/Foo.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.19 <0.9.0;
 
 import { PRBTest } from "@prb/test/PRBTest.sol";


### PR DESCRIPTION
## Reason for change:
- UNLICENSED is an invalid SPDX identifier
- Ref: https://opensource.stackexchange.com/a/12412