### PR TITLE
chore: remove the (now deprecated) prettier plugin from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Foundry-based template for developing Solidity smart contracts, with sensible 
   contracts
 - [Forge Std](https://github.com/foundry-rs/forge-std): collection of helpful contracts and cheatcodes for testing
 - [PRBTest](https://github.com/PaulRBerg/prb-test): modern collection of testing assertions and logging utilities
+- [Prettier](https://github.com/prettier/prettier): code formatter for non-Solidity files
 - [Solhint](https://github.com/protofire/solhint): linter for Solidity code
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -15,11 +15,9 @@ A Foundry-based template for developing Solidity smart contracts, with sensible 
 
 - [Forge](https://github.com/foundry-rs/foundry/blob/master/forge): compile, test, fuzz, format, and deploy smart
   contracts
-- [PRBTest](https://github.com/PaulRBerg/prb-test): modern collection of testing assertions and logging utilities
 - [Forge Std](https://github.com/foundry-rs/forge-std): collection of helpful contracts and cheatcodes for testing
+- [PRBTest](https://github.com/PaulRBerg/prb-test): modern collection of testing assertions and logging utilities
 - [Solhint](https://github.com/protofire/solhint): linter for Solidity code
-- [Prettier Plugin Solidity](https://github.com/prettier-solidity/prettier-plugin-solidity): code formatter for
-  non-Solidity files
 
 ## Getting Started
 


### PR DESCRIPTION
## Reason for change
Prettier plugin solidity is no longer used because instead of are formatting Solidity files with `forge fmt` as set by a VSCode extension or run from CLI. Prettier is now only used standalone for md,yml,json.