### PR TITLE
Fix prettier globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "build": "forge build",
     "lint": "bun run lint:sol && bun run prettier:check",
     "lint:sol": "forge fmt --check && bun solhint {script,src,test}/**/*.sol",
-    "prettier:check": "prettier --check \"**/*.{json,md,yml}\" --ignore-path=.prettierignore",
-    "prettier:write": "prettier --write \"**/*.{json,md,yml}\" --ignore-path=.prettierignore",
+    "prettier:check": "prettier --check \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
+    "prettier:write": "prettier --write \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
     "test": "forge test",
     "test:coverage": "forge coverage",
     "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "build": "forge build",
     "lint": "bun run lint:sol && bun run prettier:check",
     "lint:sol": "forge fmt --check && bun solhint {script,src,test}/**/*.sol",
-    "prettier:check": "prettier --check **/*.{json,md,yml} --ignore-path=.prettierignore",
-    "prettier:write": "prettier --write **/*.{json,md,yml} --ignore-path=.prettierignore",
+    "prettier:check": "prettier --check '**/*.{json,md,yml}' --ignore-path=.prettierignore",
+    "prettier:write": "prettier --write '**/*.{json,md,yml}' --ignore-path=.prettierignore",
     "test": "forge test",
     "test:coverage": "forge coverage",
     "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "build": "forge build",
     "lint": "bun run lint:sol && bun run prettier:check",
     "lint:sol": "forge fmt --check && bun solhint {script,src,test}/**/*.sol",
-    "prettier:check": "prettier --check '**/*.{json,md,yml}' --ignore-path=.prettierignore",
-    "prettier:write": "prettier --write '**/*.{json,md,yml}' --ignore-path=.prettierignore",
+    "prettier:check": "prettier --check \"**/*.{json,md,yml}\" --ignore-path=.prettierignore",
+    "prettier:write": "prettier --write \"**/*.{json,md,yml}\" --ignore-path=.prettierignore",
     "test": "forge test",
     "test:coverage": "forge coverage",
     "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage"


### PR DESCRIPTION
## Description ##
### Issue ###
After some testing, the glob patterns in `package.json` are not hitting all the files when there are nested folders.

### Suggestion ###
I suggest to add `\"` to prevent undesired behaviours (I tested it and everything was fixed with this approach):

![image](https://github.com/PaulRBerg/foundry-template/assets/29304078/4108c966-dc42-4edc-8b11-e557bc28edf3)

Close #48 
