### PR TITLE
chore: enclose `lint:sol` glob expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean": "rm -rf cache out",
     "build": "forge build",
     "lint": "bun run lint:sol && bun run prettier:check",
-    "lint:sol": "forge fmt --check && bun solhint {script,src,test}/**/*.sol",
+    "lint:sol": "forge fmt --check && bun solhint \"{script,src,test}/**/*.sol\"",
     "prettier:check": "prettier --check \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
     "prettier:write": "prettier --write \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
     "test": "forge test",


### PR DESCRIPTION
Need quotes around the glob expression to ensure it isn't evaluated too early. On my machine not all files are found when quotes are emitted.